### PR TITLE
Parameterize service cache

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -20,7 +20,8 @@
 #
 class nscd::config ($nscd_hosts_cache  = hiera('nscd_hosts_cache','yes'),
                     $nscd_passwd_cache = hiera('nscd_passwd_cache','no'),
-                    $nscd_group_cache  = hiera('nscd_group_cache','no')
+                    $nscd_group_cache  = hiera('nscd_group_cache','no'),
+                    $nscd_service_cache  = hiera('nscd_service_cache','yes')
                    ) {
 
 
@@ -32,6 +33,9 @@ class nscd::config ($nscd_hosts_cache  = hiera('nscd_hosts_cache','yes'),
      }
      if ! ( $nscd_group_cache in ['yes','no'] ) {
         fail("nscd_hosts_cache must be yes or no")
+     }
+     if ! ( $nscd_service_cache in ['yes','no'] ) {
+        fail("nscd_service_cache must be yes or no")
      }
 
 

--- a/templates/nscd.conf.erb
+++ b/templates/nscd.conf.erb
@@ -73,7 +73,7 @@
 	max-db-size		hosts		33554432
 
 <% unless @osfamily == 'RedHat' and @operatingsystemrelease.to_f < 6.0 -%>
-	enable-cache		services	yes
+	enable-cache		services	<%= nscd_service_cache %>
 	positive-time-to-live	services	28800
 	negative-time-to-live	services	20
 	suggested-size		services	211


### PR DESCRIPTION
Adds a config parameter to customize enable-cache for services.
I set the default to 'yes' as to remain BC, although the other parameters default to _no_.
