### PR TITLE
Refactor to puppet 4

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,13 +1,13 @@
 ---
 .travis.yml:
   extras:
-  - rvm: 2.4.0
+  - rvm: 2.4.1
     env: PUPPET_INSTALL_TYPE=agent CHECK=acceptance BEAKER_debug=true BEAKER_set=docker/centos-7
     services: docker
     sudo: required
     bundler_args: --without development
     dist: trusty
-  - rvm: 2.4.0
+  - rvm: 2.4.1
     env: PUPPET_INSTALL_TYPE=agent CHECK=acceptance BEAKER_debug=true BEAKER_set=docker/centos-6
     services: docker
     sudo: required

--- a/.sync.yml
+++ b/.sync.yml
@@ -1,0 +1,17 @@
+---
+.travis.yml:
+  extras:
+  - rvm: 2.4.0
+    env: PUPPET_INSTALL_TYPE=agent CHECK=acceptance BEAKER_debug=true BEAKER_set=docker/centos-7
+    services: docker
+    sudo: required
+    bundler_args: --without development
+    dist: trusty
+  - rvm: 2.4.0
+    env: PUPPET_INSTALL_TYPE=agent CHECK=acceptance BEAKER_debug=true BEAKER_set=docker/centos-6
+    services: docker
+    sudo: required
+    bundler_args: --without development
+    dist: trusty
+
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,13 +33,13 @@ matrix:
   - rvm: 2.4.1
     bundler_args: --without system_tests development
     env: PUPPET_VERSION="~> 4.0" CHECK=build DEPLOY_TO_FORGE=yes
-  - rvm: 2.4.0
+  - rvm: 2.4.1
     bundler_args: --without development
     dist: trusty
     env: PUPPET_INSTALL_TYPE=agent CHECK=acceptance BEAKER_debug=true BEAKER_set=docker/centos-7
     services: docker
     sudo: required
-  - rvm: 2.4.0
+  - rvm: 2.4.1
     bundler_args: --without development
     dist: trusty
     env: PUPPET_INSTALL_TYPE=agent CHECK=acceptance BEAKER_debug=true BEAKER_set=docker/centos-6

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,19 @@ matrix:
   - rvm: 2.4.1
     bundler_args: --without system_tests development
     env: PUPPET_VERSION="~> 4.0" CHECK=build DEPLOY_TO_FORGE=yes
+  - rvm: 2.4.0
+    bundler_args: --without development
+    dist: trusty
+    env: PUPPET_INSTALL_TYPE=agent CHECK=acceptance BEAKER_debug=true BEAKER_set=docker/centos-7
+    services: docker
+    sudo: required
+  - rvm: 2.4.0
+    bundler_args: --without development
+    dist: trusty
+    env: PUPPET_INSTALL_TYPE=agent CHECK=acceptance BEAKER_debug=true BEAKER_set=docker/centos-6
+    services: docker
+    sudo: required
+
 branches:
   only:
   - master

--- a/README.md
+++ b/README.md
@@ -1,16 +1,37 @@
-puppet-nscd
-===========
+# Puppet module for nscd
 
-Configure /etc/nscd.conf and nscd.
+[![Build Status](https://travis-ci.org/voxpupuli/puppet-nscd.png?branch=master)](https://travis-ci.org/voxpupuli/puppet-nscd)
+[![Code Coverage](https://coveralls.io/repos/github/voxpupuli/puppet-nscd/badge.svg?branch=master)](https://coveralls.io/github/voxpupuli/puppet-nscd)
+[![Puppet Forge](https://img.shields.io/puppetforge/v/puppet/nscd.svg)](https://forge.puppetlabs.com/puppet/nscd)
+[![Puppet Forge - downloads](https://img.shields.io/puppetforge/dt/puppet/nscd.svg)](https://forge.puppetlabs.com/puppet/nscd)
+[![Puppet Forge - endorsement](https://img.shields.io/puppetforge/e/puppet/nscd.svg)](https://forge.puppetlabs.com/puppet/nscd)
+[![Puppet Forge - scores](https://img.shields.io/puppetforge/f/puppet/nscd.svg)](https://forge.puppetlabs.com/puppet/nscd)
 
-Does little more than install the nscd package
-and support the on/off of databases passwd,
-groups and hosts to cache or not.
 
-See class::nscd for details.
+## Overview
 
-Tested on RHEL and Fedora.
+Configures `/etc/nscd.conf` and controls nscd service.
 
-The module assumes that hiera is available.
+## Examples
 
-[![Build Status](https://travis-ci.org/cernops/puppet-nscd.svg?branch=master)](https://travis-ci.org/cernops/puppet-nscd)
+```puppet
+include ::nscd
+```
+
+```puppet
+class{'nscd':
+  nscd_group_cache => 'yes',
+}
+
+## Usage
+
+Generated puppet strings documentation with examples is available from
+https://voxpupuli.org/puppet-nscd/
+
+## Authors
+
+* VoxPupuli <voxpupuli@groups.io>
+* Steve Traylen <steve.traylen@cern.ch>
+
+
+

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ https://voxpupuli.org/puppet-nscd/
 
 ## Authors
 
-* VoxPupuli <voxpupuli@groups.io>
+* Vox Pupuli <voxpupuli@groups.io>
 * Steve Traylen <steve.traylen@cern.ch>
 
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -5,6 +5,9 @@ class nscd::config inherits nscd {
   file{'/etc/nscd.conf':
     ensure  => present,
     content => template('nscd/nscd.conf.erb'),
+    owner   => root,
+    group   => root,
+    mode    => '0644',
   }
 }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,113 +1,38 @@
-# == Class: nscd
+# nscd class.
 #
-# Manages /etc/nscd.conf file and service.
+# @summary Configures /etc/ncsd.conf and controls nscd service.
 #
-# === Parameters
-#  pkg_ensure                   Desired state of nscd package.
-#                               Default is present.
-#                               type: string
-#                               valid values: 'present' or 'absent' or 'lastest'
+# @example
+#  include ::nscd
 #
-#  service_ensure               Desired state of nscd service.
-#                               Default is running.
-#                               type: string
-#                               valid values: 'running' or 'stopped'
-#
-#  service_enable               Should nscd start on boot.
-#                               Default is true.
-#                               type: boolean
-#
-#                               valid values: true or false
-#  nscd_hosts_cache::           Should nscd cache hosts queries.
-#                               Default is yes.
-#                               type: string
-#                               valid values: 'yes' or 'no'
-#
-#  nscd_passwd_cache::          Should nscd cache passwd queries.
-#                               Default is no.
-#                               type: string
-#                               valid values: 'yes' or 'no'
-#
-#  nscd_group_cache::           Should nscd cache group queries.
-#                               Default is no.
-#                               type: string
-#                               valid values: 'yes' or 'no'
-#
-#  nscd_service_cache::         Should nscd cache service queries.
-#                               Default is yes.
-#                               type: string
-#                               valid values: 'yes' or 'no'
-#
-#  nscd_threads::               How many threads should nscd use.
-#                               Default is 4.
-#                               type: integer
-#
-#  nscd_paranoia::              Should nscd restart itself periodically.
-#                               Default is no.
-#                               type: string
-#                               valid values: 'yes' or 'no'
-#
-#  nscd_restart_interval::      The interval in that nscd restarts itself
-#                               if nscd_paranoia is enabled.
-#                               Default is 3600.
-#                               type: integer
-#
-# === Examples
-#
-#  class { 'nscd': }
-#
-# === Authors
-#
-# Steve Traylen <steve.traylen@cern.ch>
-# Arnold Bechtoldt <mail@arnoldbechtoldt.com>
-# Martin Pfeifer <martin.pfeifer@gmail.com>
-#
-# === Copyright
-#
-# Copyright 2011 CERN Steve Traylen
-#
+# @param pkg_ensure state of nscd package.
+# @param service_ensure state of nscd service ensure
+# @param service_enable state of nscd service enable
+# @param hosts_cache should nscd cache host entries
+# @param passwd_cache should nscd cache passwd entries
+# @param group_cache should nscd cache group entries
+# @param services_cache should nscd cache service entries.
+# @param threads number of threads
+# @prarm paranoia  enable internal restart mode.
+# @param restart_interval nscd internal restart interval
 class nscd (
-  $pkg_ensure            = 'present',
-  $service_ensure        = 'running',
-  $service_enable        = true,
-  $nscd_hosts_cache      = hiera('nscd_hosts_cache','yes'),
-  $nscd_passwd_cache     = hiera('nscd_passwd_cache','no'),
-  $nscd_group_cache      = hiera('nscd_group_cache','no'),
-  $nscd_service_cache    = hiera('nscd_service_cache','yes'),
-  $nscd_threads          = hiera('nscd_threads','4'),
-  $nscd_paranoia         = hiera('nscd_paranoia','no'),
-  $nscd_restart_interval = hiera('nscd_restart_interval','3600')
+  Enum['present','absent','latest'] $pkg_ensure  = 'present',
+  Boolean  $service_ensure   = true,
+  Boolean  $service_enable   = true,
+  Boolean  $hosts_cache      = true,
+  Boolean  $passwd_cache     = false,
+  Boolean  $group_cache      = false,
+  Boolean  $services_cache   = true,
+  Integer  $threads          = 4,
+  Boolean  $paranoia         = true,
+  Integer  $restart_interval = 3600,
 ) {
 
-  if ! ( $pkg_ensure in ['present','absent','latest'] ) {
-    fail('pkg_ensure must be present, absent or latest')
-  }
-  if ! ( $service_ensure in ['running','stopped'] ) {
-    fail('service_ensure must be running or stopped')
-  }
-  if ! ( $nscd_hosts_cache in ['yes','no'] ) {
-    fail('nscd_hosts_cache must be yes or no')
-  }
-  if ! ( $nscd_passwd_cache in ['yes','no'] ) {
-    fail('nscd_hosts_cache must be yes or no')
-  }
-  if ! ( $nscd_group_cache in ['yes','no'] ) {
-    fail('nscd_hosts_cache must be yes or no')
-  }
-  if ! ( $nscd_service_cache in ['yes','no'] ) {
-    fail('nscd_service_cache must be yes or no')
-  }
-  if ! ( $nscd_paranoia in ['yes','no'] ) {
-    fail('nscd_paranoia must be yes or no')
-  }
+  contain ::nscd::install
+  contain ::nscd::config
+  contain ::nscd::service
 
-  include ::nscd::install
-  include ::nscd::config
-  include ::nscd::service
-
-  anchor{"${name}::begin":}
-  -> Class['nscd::install']
+  Class['nscd::install']
   -> Class['nscd::config']
   ~> Class['nscd::service']
-  -> anchor{"${name}::end":}
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,16 +16,16 @@
 # @prarm paranoia  enable internal restart mode.
 # @param restart_interval nscd internal restart interval
 class nscd (
-  Enum['present','absent','latest'] $pkg_ensure  = 'present',
-  Boolean  $service_ensure   = true,
-  Boolean  $service_enable   = true,
-  Boolean  $hosts_cache      = true,
-  Boolean  $passwd_cache     = false,
-  Boolean  $group_cache      = false,
-  Boolean  $services_cache   = true,
-  Integer  $threads          = 4,
-  Boolean  $paranoia         = true,
-  Integer  $restart_interval = 3600,
+  Enum['present','absent','latest'] $pkg_ensure       = 'present',
+  Boolean                           $service_ensure   = true,
+  Boolean                           $service_enable   = true,
+  Boolean                           $hosts_cache      = true,
+  Boolean                           $passwd_cache     = false,
+  Boolean                           $group_cache      = false,
+  Boolean                           $services_cache   = true,
+  Integer                           $threads          = 4,
+  Boolean                           $paranoia         = true,
+  Integer                           $restart_interval = 3600,
 ) {
 
   contain ::nscd::install

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,6 +1,3 @@
-# == Class: nscd::install
-# Installs nscd packages.
-#
 class nscd::install (
   $pkg_ensure = $nscd::pkg_ensure
 ) inherits nscd {

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,13 +1,9 @@
-# == Class: nscd::service
-# Controls the nscd service.
 class nscd::service (
   $service_ensure = $nscd::service_ensure,
   $service_enable = $nscd::service_enable,
 ) inherits nscd {
   service{'nscd':
-    ensure     => $service_ensure,
-    enable     => $service_enable,
-    hasstatus  => true,
-    hasrestart => true,
+    ensure => $service_ensure,
+    enable => $service_enable,
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,10 @@
   "issues": "https://github.com/voxpupuli/puppet-nscd/issues",
   "tags": ["nscd", "dns", "dnscache", "cache" ],
   "dependencies": [ 
-    { "name": "puppetlabs/stdlib", "version_requirement": ">=2.2.1 < 5" }
+    {
+      "name": "puppetlabs-stdlib",
+      "version_requirement": ">= 4.6.0 < 5.0.0"
+    }
   ],
   "requirements": [
     {

--- a/metadata.json
+++ b/metadata.json
@@ -12,7 +12,7 @@
   "dependencies": [ 
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 4.6.0 < 5.0.0"
+      "version_requirement": ">=  4.13.1 < 5.0.0"
     }
   ],
   "requirements": [

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper_acceptance'
+
+describe 'nscd class' do
+  context 'default parameters' do
+    # Using puppet_apply as a helper
+    it 'works idempotently with no errors' do
+      pp = <<-EOS
+      class { 'nscd':}
+      EOS
+
+      # Run it twice and test for idempotency
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
+
+    describe package('nscd') do
+      it { is_expected.to be_installed }
+    end
+    describe service('nscd') do
+      it { is_expected.to be_running }
+    end
+    describe file('/etc/nscd.conf') do
+      it { is_expected.to be_file }
+    end
+  end
+end

--- a/spec/classes/nscd_spec.rb
+++ b/spec/classes/nscd_spec.rb
@@ -1,28 +1,86 @@
 require 'spec_helper'
 describe 'nscd' do
-  context 'with defaults for all parameters' do
-    it { is_expected.to contain_class('nscd::install') }
-    it { is_expected.to contain_class('nscd::config') }
-    it { is_expected.to contain_class('nscd::service') }
-    it { is_expected.to contain_package('nscd').with_ensure('present') }
-    it { is_expected.to contain_service('nscd').with_ensure('running') }
-  end
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts
+      end
 
-  context 'with pkg_ensure => "absent"' do
-    let(:params) { { pkg_ensure: 'absent' } }
+      context 'with defaults for all parameters' do
+        it { is_expected.to contain_class('nscd::install') }
+        it { is_expected.to contain_class('nscd::config') }
+        it { is_expected.to contain_class('nscd::service') }
+        it { is_expected.to contain_package('nscd').with_ensure('present') }
+        it { is_expected.to contain_service('nscd').with_ensure(true) }
+      end
 
-    it { is_expected.to contain_package('nscd').with_ensure('absent') }
-  end
+      context 'with pkg_ensure => "absent"' do
+        let(:params) { { pkg_ensure: 'absent' } }
 
-  context 'with service_ensure => "stopped"' do
-    let(:params) { { service_ensure: 'stopped' } }
+        it { is_expected.to contain_package('nscd').with_ensure('absent') }
+      end
 
-    it { is_expected.to contain_service('nscd').with_ensure('stopped') }
-  end
+      context 'with service_ensure => false' do
+        let(:params) { { service_ensure: false } }
 
-  context 'with service_enable => false' do
-    let(:params) { { service_enable: false } }
+        it { is_expected.to contain_service('nscd').with_ensure(false) }
+      end
 
-    it { is_expected.to contain_service('nscd').with_enable(false) }
+      context 'with service_enable => false' do
+        let(:params) { { service_enable: false } }
+
+        it { is_expected.to contain_service('nscd').with_enable(false) }
+      end
+      context 'with nscd_restart_interval set' do
+        let(:params) { { restart_interval: 1000 } }
+
+        it { is_expected.to contain_file('/etc/nscd.conf').with_content(%r{^\s*restart-interval\s+1000$}) }
+      end
+      context 'with passwd_cache set false' do
+        let(:params) { { passwd_cache: false } }
+
+        it { is_expected.to contain_file('/etc/nscd.conf').with_content(%r{^\s*enable-cache\s+passwd\s+no$}) }
+      end
+      context 'with passwd_cache set true' do
+        let(:params) { { passwd_cache: true } }
+
+        it { is_expected.to contain_file('/etc/nscd.conf').with_content(%r{^\s*enable-cache\s+passwd\s+yes$}) }
+      end
+      context 'with group_cache set true' do
+        let(:params) { { group_cache: true } }
+
+        it { is_expected.to contain_file('/etc/nscd.conf').with_content(%r{^\s*enable-cache\s+group\s+yes$}) }
+      end
+      context 'with group_cache set false' do
+        let(:params) { { group_cache: false } }
+
+        it { is_expected.to contain_file('/etc/nscd.conf').with_content(%r{^\s*enable-cache\s+group\s+no$}) }
+      end
+      context 'with hosts_cache set false' do
+        let(:params) { { hosts_cache: false } }
+
+        it { is_expected.to contain_file('/etc/nscd.conf').with_content(%r{^\s*enable-cache\s+hosts\s+no$}) }
+      end
+      context 'with hosts_cache set true' do
+        let(:params) { { hosts_cache: true } }
+
+        it { is_expected.to contain_file('/etc/nscd.conf').with_content(%r{^\s*enable-cache\s+hosts\s+yes$}) }
+      end
+      case facts[:operatingsystemmajrelease]
+      when '5'
+        it { is_expected.to contain_file('/etc/nscd.conf').without_content(%r{^\s*enable-cache\s+services.*$}) }
+      else
+        context 'with services_cache set false' do
+          let(:params) { { services_cache: false } }
+
+          it { is_expected.to contain_file('/etc/nscd.conf').with_content(%r{^\s*enable-cache\s+services\s+no$}) }
+        end
+        context 'with services_cache set true' do
+          let(:params) { { services_cache: true } }
+
+          it { is_expected.to contain_file('/etc/nscd.conf').with_content(%r{^\s*enable-cache\s+services\s+yes$}) }
+        end
+      end
+    end
   end
 end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,0 +1,21 @@
+require 'beaker-rspec'
+require 'beaker/puppet_install_helper'
+
+run_puppet_install_helper unless ENV['BEAKER_provision'] == 'no'
+
+RSpec.configure do |c|
+  # Project root
+  proj_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
+
+  # Readable test descriptions
+  c.formatter = :documentation
+
+  # Configure all nodes in nodeset
+  c.before :suite do
+    # Install module and dependencies
+    puppet_module_install(source: proj_root, module_name: 'nscd')
+    hosts.each do |host|
+      on host, puppet('module', 'install', 'puppetlabs-stdlib'), acceptable_exit_codes: [0]
+    end
+  end
+end

--- a/templates/nscd.conf.erb
+++ b/templates/nscd.conf.erb
@@ -34,16 +34,16 @@
 
 
 #	logfile			/var/log/nscd.log
-	threads			<%= @nscd_threads %>
+	threads			<%= @threads %>
 #	max-threads		32
 	server-user		nscd
 #	stat-user		somebody
 	debug-level		0
 #	reload-count		5
-	paranoia		<%= @nscd_paranoia %>
- 	restart-interval	<%= @nscd_restart_interval %>
+	paranoia		<%= @paranoia ? 'yes' : 'no' %>
+ 	restart-interval	<%= @restart_interval %>
 
-	enable-cache		passwd		<%= @nscd_passwd_cache %>
+	enable-cache		passwd		<%= @passwd_cache ? 'yes' : 'no' %>
 	positive-time-to-live	passwd		600
 	negative-time-to-live	passwd		20
 	suggested-size		passwd		211
@@ -53,7 +53,7 @@
 	max-db-size		passwd		33554432
 	auto-propagate		passwd		yes
 
-	enable-cache		group		<%= @nscd_group_cache %>
+	enable-cache		group		<%= @group_cache ? 'yes' : 'no' %>
 	positive-time-to-live	group		3600
 	negative-time-to-live	group		60
 	suggested-size		group		211
@@ -63,7 +63,7 @@
 	max-db-size		group		33554432
 	auto-propagate		group		yes
 
-	enable-cache		hosts		<%= @nscd_hosts_cache %>
+	enable-cache		hosts		<%= @hosts_cache ? 'yes' : 'no' %>
 	positive-time-to-live	hosts		3600
 	negative-time-to-live	hosts		20
 	suggested-size		hosts		211
@@ -72,8 +72,8 @@
 	shared			hosts		yes
 	max-db-size		hosts		33554432
 
-<% unless @osfamily == 'RedHat' and @operatingsystemrelease.to_f < 6.0 -%>
-	enable-cache		services	<%= @nscd_service_cache %>
+<% unless @osfamily == 'RedHat' and @operatingsystemmajrelease == '5' -%>
+	enable-cache		services	<%= @services_cache ? 'yes' : 'no' %>
 	positive-time-to-live	services	28800
 	negative-time-to-live	services	20
 	suggested-size		services	211

--- a/templates/nscd.conf.erb
+++ b/templates/nscd.conf.erb
@@ -72,7 +72,7 @@
 	shared			hosts		yes
 	max-db-size		hosts		33554432
 
-<% unless @osfamily == 'RedHat' and @operatingsystemmajrelease == '5' -%>
+<% unless @facts['os']['family'] == 'RedHat' and @facts['os']['release']['major'] == '5' -%>
 	enable-cache		services	<%= @services_cache ? 'yes' : 'no' %>
 	positive-time-to-live	services	28800
 	negative-time-to-live	services	20


### PR DESCRIPTION
    This closes #16, closes #14, closes #12
    
    Parameter names now have `nscd_` prefix removed.
    
    * `nscd_hosts_cache` becomes `hosts_cache`
    * `nscd_passwd_cache` becomes  `passwd_cache`
    * `nscd_group_cache` becomes `group_cache`
    * `nscd_service_cache` becomes `services_cache`
    * `nscd_threads` becomes `threads`
    * `nscd_paranoia` becomes `paranoia`
    * `nscd_restart_interval` becomes `restart_interval`
    
    Note that it is now  `services_cache` with an `s` to be consistant
    with other parameters.
    
    The parameters `hosts_cache`, `passwd_cache`, `group_cache`,
    `services_cache` and `paranoia` are now  booleans
    rather than `yes` or `no` string.
