### PR TITLE
On Ubuntu - nscd runs as root by default. fails to start as nscd user.

### DIFF
--- a/templates/nscd.conf.erb
+++ b/templates/nscd.conf.erb
@@ -36,7 +36,9 @@
 #	logfile			/var/log/nscd.log
 	threads			<%= @threads %>
 #	max-threads		32
-	server-user		nscd
+<% if @osfamily != 'Debian' -%>
+        server-user             nscd
+<% end -%>
 #	stat-user		somebody
 	debug-level		0
 #	reload-count		5


### PR DESCRIPTION
Alternatively one could change how Ubuntu does things, and create nscd user to run it as.. (and what else might possibly need changing for it to run as nscd user).. but that would be go to against Ubuntu defaults.
