### PR TITLE
Fixes #26 allow ttl to be configured

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,17 +15,33 @@
 # @param threads number of threads
 # @prarm paranoia  enable internal restart mode.
 # @param restart_interval nscd internal restart interval
+# @param passwd_positive_ttl positive time to live for passwords database.
+# @param passwd_negative_ttl negative time to live for passwords database.
+# @param group_positive_ttl positive time to live for groups database.
+# @param group_negative_ttl negative time to live for groups database.
+# @param hosts_positive_ttl positive time to live for hosts database.
+# @param hosts_negative_ttl negative time to live for hosts database.
+# @param services_positive_ttl positive time to live for services database.
+# @param services_negative_ttl negative time to live for services database.
 class nscd (
-  Enum['present','absent','latest'] $pkg_ensure       = 'present',
-  Boolean                           $service_ensure   = true,
-  Boolean                           $service_enable   = true,
-  Boolean                           $hosts_cache      = true,
-  Boolean                           $passwd_cache     = false,
-  Boolean                           $group_cache      = false,
-  Boolean                           $services_cache   = true,
-  Integer                           $threads          = 4,
-  Boolean                           $paranoia         = true,
-  Integer                           $restart_interval = 3600,
+  Enum['present','absent','latest'] $pkg_ensure            = 'present',
+  Boolean                           $service_ensure        = true,
+  Boolean                           $service_enable        = true,
+  Boolean                           $hosts_cache           = true,
+  Boolean                           $passwd_cache          = false,
+  Boolean                           $group_cache           = false,
+  Boolean                           $services_cache        = true,
+  Integer                           $threads               = 4,
+  Boolean                           $paranoia              = true,
+  Integer                           $restart_interval      = 3600,
+  Integer                           $passwd_negative_ttl   = 20,
+  Integer                           $passwd_positive_ttl   = 600,
+  Integer                           $group_negative_ttl    = 60,
+  Integer                           $group_positive_ttl    = 3600,
+  Integer                           $hosts_negative_ttl    = 20,
+  Integer                           $hosts_positive_ttl    = 3600,
+  Integer                           $services_negative_ttl = 20,
+  Integer                           $services_positive_ttl = 28800,
 ) {
 
   contain ::nscd::install

--- a/spec/classes/nscd_spec.rb
+++ b/spec/classes/nscd_spec.rb
@@ -12,6 +12,20 @@ describe 'nscd' do
         it { is_expected.to contain_class('nscd::service') }
         it { is_expected.to contain_package('nscd').with_ensure('present') }
         it { is_expected.to contain_service('nscd').with_ensure(true) }
+        it { is_expected.to contain_file('/etc/nscd.conf').with_content(%r{^\s*positive-time-to-live\s+passwd\s+600$}) }
+        it { is_expected.to contain_file('/etc/nscd.conf').with_content(%r{^\s*negative-time-to-live\s+passwd\s+20$}) }
+        it { is_expected.to contain_file('/etc/nscd.conf').with_content(%r{^\s*positive-time-to-live\s+group\s+3600$}) }
+        it { is_expected.to contain_file('/etc/nscd.conf').with_content(%r{^\s*negative-time-to-live\s+group\s+60$}) }
+        it { is_expected.to contain_file('/etc/nscd.conf').with_content(%r{^\s*positive-time-to-live\s+hosts\s+3600$}) }
+        it { is_expected.to contain_file('/etc/nscd.conf').with_content(%r{^\s*negative-time-to-live\s+hosts\s+20$}) }
+        case facts[:operatingsystemmajrelease]
+        when '5'
+          it { is_expected.to contain_file('/etc/nscd.conf').without_content(%r{^\s*positive-time-to-live\s+services.*$}) }
+          it { is_expected.to contain_file('/etc/nscd.conf').without_content(%r{^\s*negative-time-to-live\s+services.*$}) }
+        else
+          it { is_expected.to contain_file('/etc/nscd.conf').with_content(%r{^\s*positive-time-to-live\s+services\s+28800$}) }
+          it { is_expected.to contain_file('/etc/nscd.conf').with_content(%r{^\s*negative-time-to-live\s+services\s+20$}) }
+        end
       end
 
       context 'with pkg_ensure => "absent"' do
@@ -31,10 +45,34 @@ describe 'nscd' do
 
         it { is_expected.to contain_service('nscd').with_enable(false) }
       end
-      context 'with nscd_restart_interval set' do
-        let(:params) { { restart_interval: 1000 } }
+      context 'with all integer values set' do
+        let(:params) do
+          { restart_interval: 1001,
+            passwd_negative_ttl: 1002,
+            passwd_positive_ttl: 1003,
+            group_negative_ttl: 1004,
+            group_positive_ttl: 1005,
+            hosts_negative_ttl: 1006,
+            hosts_positive_ttl: 1007,
+            services_negative_ttl: 1008,
+            services_positive_ttl: 1009 }
+        end
 
-        it { is_expected.to contain_file('/etc/nscd.conf').with_content(%r{^\s*restart-interval\s+1000$}) }
+        it { is_expected.to contain_file('/etc/nscd.conf').with_content(%r{^\s*restart-interval\s+1001$}) }
+        it { is_expected.to contain_file('/etc/nscd.conf').with_content(%r{^\s*negative-time-to-live\s+passwd\s+1002$}) }
+        it { is_expected.to contain_file('/etc/nscd.conf').with_content(%r{^\s*positive-time-to-live\s+passwd\s+1003$}) }
+        it { is_expected.to contain_file('/etc/nscd.conf').with_content(%r{^\s*negative-time-to-live\s+group\s+1004$}) }
+        it { is_expected.to contain_file('/etc/nscd.conf').with_content(%r{^\s*positive-time-to-live\s+group\s+1005$}) }
+        it { is_expected.to contain_file('/etc/nscd.conf').with_content(%r{^\s*negative-time-to-live\s+hosts\s+1006$}) }
+        it { is_expected.to contain_file('/etc/nscd.conf').with_content(%r{^\s*positive-time-to-live\s+hosts\s+1007$}) }
+        case facts[:operatingsystemmajrelease]
+        when '5'
+          it { is_expected.to contain_file('/etc/nscd.conf').without_content(%r{^\s*negative-time-to-live\s+services.*$}) }
+          it { is_expected.to contain_file('/etc/nscd.conf').without_content(%r{^\s*positive-time-to-live\s+services.*$}) }
+        else
+          it { is_expected.to contain_file('/etc/nscd.conf').with_content(%r{^\s*negative-time-to-live\s+services\s+1008$}) }
+          it { is_expected.to contain_file('/etc/nscd.conf').with_content(%r{^\s*positive-time-to-live\s+services\s+1009$}) }
+        end
       end
       context 'with passwd_cache set false' do
         let(:params) { { passwd_cache: false } }

--- a/templates/nscd.conf.erb
+++ b/templates/nscd.conf.erb
@@ -44,8 +44,8 @@
  	restart-interval	<%= @restart_interval %>
 
 	enable-cache		passwd		<%= @passwd_cache ? 'yes' : 'no' %>
-	positive-time-to-live	passwd		600
-	negative-time-to-live	passwd		20
+	positive-time-to-live	passwd		<%= @passwd_positive_ttl %>
+	negative-time-to-live	passwd		<%= @passwd_negative_ttl %>
 	suggested-size		passwd		211
 	check-files		passwd		yes
 	persistent		passwd		yes
@@ -54,8 +54,8 @@
 	auto-propagate		passwd		yes
 
 	enable-cache		group		<%= @group_cache ? 'yes' : 'no' %>
-	positive-time-to-live	group		3600
-	negative-time-to-live	group		60
+	positive-time-to-live	group		<%= @group_positive_ttl %>
+	negative-time-to-live	group		<%= @group_negative_ttl %>
 	suggested-size		group		211
 	check-files		group		yes
 	persistent		group		yes
@@ -64,8 +64,8 @@
 	auto-propagate		group		yes
 
 	enable-cache		hosts		<%= @hosts_cache ? 'yes' : 'no' %>
-	positive-time-to-live	hosts		3600
-	negative-time-to-live	hosts		20
+	positive-time-to-live	hosts		<%= @hosts_positive_ttl %>
+	negative-time-to-live	hosts		<%= @hosts_negative_ttl %>
 	suggested-size		hosts		211
 	check-files		hosts		yes
 	persistent		hosts		yes
@@ -74,8 +74,8 @@
 
 <% unless @facts['os']['family'] == 'RedHat' and @facts['os']['release']['major'] == '5' -%>
 	enable-cache		services	<%= @services_cache ? 'yes' : 'no' %>
-	positive-time-to-live	services	28800
-	negative-time-to-live	services	20
+	positive-time-to-live	services	<%= @services_positive_ttl %>
+	negative-time-to-live	services	<%= @services_negative_ttl %>
 	suggested-size		services	211
 	check-files		services	yes
 	persistent		services	yes


### PR DESCRIPTION
Eight new variables defaulting to redhat defaults.

* passwd_negative_ttl
* passwd_positive_ttl
* group_negative_ttl
* group_positive_ttl
* hosts_negative_ttl
* hosts_positive_ttl
* services_negative_ttl
* services_positive_ttl

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
