### PR TITLE
Fixes #15 use full reference to variable names

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,10 +1,25 @@
-# == Class nscd::config
-# Configures nscd.
-#
-class nscd::config inherits nscd {
+# @api private
+# This class handles the configuration file. Avoid modifying private classes.
+class nscd::config {
   file{'/etc/nscd.conf':
     ensure  => present,
-    content => template('nscd/nscd.conf.erb'),
+    content => epp('nscd/nscd.conf.epp', {
+      'threads'               => $nscd::threads,
+      'paranoia'              => $nscd::paranoia,
+      'restart_interval'      => $nscd::restart_interval,
+      'passwd_cache'          => $nscd::passwd_cache,
+      'passwd_positive_ttl'   => $nscd::passwd_positive_ttl,
+      'passwd_negative_ttl'   => $nscd::passwd_negative_ttl,
+      'group_cache'           => $nscd::group_cache,
+      'group_positive_ttl'    => $nscd::group_positive_ttl,
+      'group_negative_ttl'    => $nscd::group_negative_ttl,
+      'hosts_cache'           => $nscd::hosts_cache,
+      'hosts_positive_ttl'    => $nscd::hosts_positive_ttl,
+      'hosts_negative_ttl'    => $nscd::hosts_negative_ttl,
+      'services_cache'        => $nscd::services_cache,
+      'services_positive_ttl' => $nscd::services_positive_ttl,
+      'services_negative_ttl' => $nscd::services_negative_ttl,
+      }),
     owner   => root,
     group   => root,
     mode    => '0644',

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,5 +1,5 @@
-class nscd::install (
-  $pkg_ensure = $nscd::pkg_ensure
-) inherits nscd {
-  ensure_packages('nscd', { ensure => $pkg_ensure, })
+# @api private
+# This class handles the installation. Avoid modifying private classes.
+class nscd::install {
+  ensure_packages('nscd', { ensure => $nscd::pkg_ensure, })
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,9 +1,8 @@
-class nscd::service (
-  $service_ensure = $nscd::service_ensure,
-  $service_enable = $nscd::service_enable,
-) inherits nscd {
+# @api private
+# This class handles the service. Avoid modifying private classes.
+class nscd::service {
   service{'nscd':
-    ensure => $service_ensure,
-    enable => $service_enable,
+    ensure => $nscd::service_ensure,
+    enable => $nscd::service_enable,
   }
 }

--- a/templates/nscd.conf.epp
+++ b/templates/nscd.conf.epp
@@ -1,3 +1,19 @@
+<%- | Integer $threads,
+      Boolean $paranoia,
+      Integer $restart_interval,
+      Boolean $passwd_cache,
+      Integer $passwd_positive_ttl,
+      Integer $passwd_negative_ttl,
+      Boolean $group_cache,
+      Integer $group_positive_ttl,
+      Integer $group_negative_ttl,
+      Boolean $hosts_cache,
+      Integer $hosts_positive_ttl,
+      Integer $hosts_negative_ttl,
+      Boolean $services_cache,
+      Integer $services_positive_ttl,
+      Integer $services_negative_ttl,
+| -%>
 # Configuration file installed from nscd puppet
 # module.
 
@@ -34,28 +50,39 @@
 
 
 #	logfile			/var/log/nscd.log
-	threads			<%= @threads %>
+	threads			<%= $threads %>
 #	max-threads		32
 	server-user		nscd
 #	stat-user		somebody
 	debug-level		0
 #	reload-count		5
-	paranoia		<%= @paranoia ? 'yes' : 'no' %>
- 	restart-interval	<%= @restart_interval %>
+<% if $paranoia { -%>
+	paranoia		yes
+<% } else { -%>
+	paranoia		no
+<% } -%>
+	restart-interval	<%= $restart_interval %>
 
-	enable-cache		passwd		<%= @passwd_cache ? 'yes' : 'no' %>
-	positive-time-to-live	passwd		<%= @passwd_positive_ttl %>
-	negative-time-to-live	passwd		<%= @passwd_negative_ttl %>
+<% if $passwd_cache { -%>
+	enable-cache		passwd		yes
+<% } else { -%>
+	enable-cache		passwd		no
+<% } -%>
+	positive-time-to-live	passwd		<%= $passwd_positive_ttl %>
+	negative-time-to-live	passwd		<%= $passwd_negative_ttl %>
 	suggested-size		passwd		211
 	check-files		passwd		yes
 	persistent		passwd		yes
 	shared			passwd		yes
 	max-db-size		passwd		33554432
 	auto-propagate		passwd		yes
-
-	enable-cache		group		<%= @group_cache ? 'yes' : 'no' %>
-	positive-time-to-live	group		<%= @group_positive_ttl %>
-	negative-time-to-live	group		<%= @group_negative_ttl %>
+<% if $group_cache { -%>
+	enable-cache		group		yes
+<% } else { -%>
+	enable-cache		group		no
+<% } -%>
+	positive-time-to-live	group		<%= $group_positive_ttl %>
+	negative-time-to-live	group		<%= $group_negative_ttl %>
 	suggested-size		group		211
 	check-files		group		yes
 	persistent		group		yes
@@ -63,24 +90,32 @@
 	max-db-size		group		33554432
 	auto-propagate		group		yes
 
-	enable-cache		hosts		<%= @hosts_cache ? 'yes' : 'no' %>
-	positive-time-to-live	hosts		<%= @hosts_positive_ttl %>
-	negative-time-to-live	hosts		<%= @hosts_negative_ttl %>
+<% if $hosts_cache { -%>
+	enable-cache		hosts		yes
+<% } else { -%>
+	enable-cache		hosts		no
+<% } -%>
+	positive-time-to-live	hosts		<%= $hosts_positive_ttl %>
+	negative-time-to-live	hosts		<%= $hosts_negative_ttl %>
 	suggested-size		hosts		211
 	check-files		hosts		yes
 	persistent		hosts		yes
 	shared			hosts		yes
 	max-db-size		hosts		33554432
 
-<% unless @facts['os']['family'] == 'RedHat' and @facts['os']['release']['major'] == '5' -%>
-	enable-cache		services	<%= @services_cache ? 'yes' : 'no' %>
-	positive-time-to-live	services	<%= @services_positive_ttl %>
-	negative-time-to-live	services	<%= @services_negative_ttl %>
+<% unless $facts['os']['family'] == 'RedHat' and $facts['os']['release']['major'] == '5' { -%>
+<% if $services_cache { -%>
+	enable-cache		services	yes
+<% } else { -%>
+	enable-cache		services	no
+<% } -%>
+	positive-time-to-live	services	<%= $services_positive_ttl %>
+	negative-time-to-live	services	<%= $services_negative_ttl %>
 	suggested-size		services	211
 	check-files		services	yes
 	persistent		services	yes
 	shared			services	yes
 	max-db-size		services	33554432
-<% end -%>
+<% } -%>
 
 


### PR DESCRIPTION
As per style guide and puppetlabs-ntp avoid use
of inherits.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
