### PR TITLE
New option max-threads defaulting to 32

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,7 +12,8 @@
 # @param passwd_cache should nscd cache passwd entries
 # @param group_cache should nscd cache group entries
 # @param services_cache should nscd cache service entries.
-# @param threads number of threads
+# @param threads number of threads.
+# @param max_threads maximum number of threads.
 # @prarm paranoia  enable internal restart mode.
 # @param restart_interval nscd internal restart interval
 # @param passwd_positive_ttl positive time to live for passwords database.
@@ -32,6 +33,7 @@ class nscd (
   Boolean                           $group_cache           = false,
   Boolean                           $services_cache        = true,
   Integer                           $threads               = 4,
+  Integer                           $max_threads           = 32,
   Boolean                           $paranoia              = true,
   Integer                           $restart_interval      = 3600,
   Integer                           $passwd_negative_ttl   = 20,

--- a/spec/classes/nscd_spec.rb
+++ b/spec/classes/nscd_spec.rb
@@ -18,6 +18,8 @@ describe 'nscd' do
         it { is_expected.to contain_file('/etc/nscd.conf').with_content(%r{^\s*negative-time-to-live\s+group\s+60$}) }
         it { is_expected.to contain_file('/etc/nscd.conf').with_content(%r{^\s*positive-time-to-live\s+hosts\s+3600$}) }
         it { is_expected.to contain_file('/etc/nscd.conf').with_content(%r{^\s*negative-time-to-live\s+hosts\s+20$}) }
+        it { is_expected.to contain_file('/etc/nscd.conf').with_content(%r{^\s*threads\s+4$}) }
+        it { is_expected.to contain_file('/etc/nscd.conf').with_content(%r{^\s*max-threads\s+32$}) }
         case facts[:operatingsystemmajrelease]
         when '5'
           it { is_expected.to contain_file('/etc/nscd.conf').without_content(%r{^\s*positive-time-to-live\s+services.*$}) }
@@ -47,7 +49,10 @@ describe 'nscd' do
       end
       context 'with all integer values set' do
         let(:params) do
-          { restart_interval: 1001,
+          {
+            threads: 999,
+            max_threads: 1000,
+            restart_interval: 1001,
             passwd_negative_ttl: 1002,
             passwd_positive_ttl: 1003,
             group_negative_ttl: 1004,
@@ -55,9 +60,12 @@ describe 'nscd' do
             hosts_negative_ttl: 1006,
             hosts_positive_ttl: 1007,
             services_negative_ttl: 1008,
-            services_positive_ttl: 1009 }
+            services_positive_ttl: 1009
+          }
         end
 
+        it { is_expected.to contain_file('/etc/nscd.conf').with_content(%r{^\s*threads\s+999$}) }
+        it { is_expected.to contain_file('/etc/nscd.conf').with_content(%r{^\s*max-threads\s+1000$}) }
         it { is_expected.to contain_file('/etc/nscd.conf').with_content(%r{^\s*restart-interval\s+1001$}) }
         it { is_expected.to contain_file('/etc/nscd.conf').with_content(%r{^\s*negative-time-to-live\s+passwd\s+1002$}) }
         it { is_expected.to contain_file('/etc/nscd.conf').with_content(%r{^\s*positive-time-to-live\s+passwd\s+1003$}) }

--- a/templates/nscd.conf.erb
+++ b/templates/nscd.conf.erb
@@ -35,7 +35,7 @@
 
 #	logfile			/var/log/nscd.log
 	threads			<%= @threads %>
-#	max-threads		32
+        max-threads		<%= @max_threads %>
 	server-user		nscd
 #	stat-user		somebody
 	debug-level		0


### PR DESCRIPTION
This will add `max-threads 32` to default configurations
but that is the default for nscd.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
