### PR TITLE
Drop EOL EL6

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -2,7 +2,6 @@
 .travis.yml:
   secure: "lBcc0WYIK5ZETsNeS2jlc71o1RXiM96tvLG7TVv4WB/fTrntcQQ8bKHTAmtY2rHhi9w+KSyPqTJFqKcI/xTxJ6iIqTINoRLnEznfUclAoyYdxrkjT74UyZTf+dw1jiqLhqd6DIbQFHZ5WXob/ta8bnw5qwS9uw/tOzPJKRFXfcw="
   docker_sets:
-    - set: centos6-64
     - set: centos7-64
     - set: ubuntu1604-64
     - set: ubuntu1804-64

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,14 +26,6 @@ jobs:
       env: PUPPET_VERSION="~> 5.0" CHECK=build DEPLOY_TO_FORGE=yes
     - rvm: 2.5.3
       bundler_args: --without development release
-      env: BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_setfile=centos6-64 CHECK=beaker
-      services: docker
-    - rvm: 2.5.3
-      bundler_args: --without development release
-      env: BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_setfile=centos6-64 CHECK=beaker
-      services: docker
-    - rvm: 2.5.3
-      bundler_args: --without development release
       env: BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_setfile=centos7-64 CHECK=beaker
       services: docker
     - rvm: 2.5.3

--- a/metadata.json
+++ b/metadata.json
@@ -48,7 +48,6 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "6",
         "7",
         "8"
       ]
@@ -56,7 +55,6 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "6",
         "7",
         "8"
       ]
@@ -64,14 +62,12 @@
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "6",
         "7"
       ]
     },
     {
       "operatingsystem": "Scientific",
       "operatingsystemrelease": [
-        "6",
         "7"
       ]
     }


### PR DESCRIPTION
Now that CentOS 6 is EOL and is being removed from the mirror network we have no way to test this anymore.