### PR TITLE
Update debian, ubuntu and puppet supported oses

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -23,26 +23,23 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 5.5.8 < 7.0.0"
+      "version_requirement": ">= 6.0.0 < 8.0.0"
     }
   ],
   "operatingsystem_support": [
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "16.04"
-      ]
-    },
-    {
-      "operatingsystem": "Ubuntu",
-      "operatingsystemrelease": [
-        "18.04"
+        "16.04",
+        "18.04",
+        "20.04"
       ]
     },
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "8"
+        "9",
+        "10"
       ]
     },
     {


### PR DESCRIPTION
#### Update debian and ubuntu supported oses

* Drop debian 8
* Add debian 9 and 10
* Add ubuntu 20.04.
* Drop puppet 5 support
* Add puppet 7 support
