### PR TITLE
change module dependency syntax

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -16,7 +16,7 @@
   ],
   "dependencies": [
     {
-      "name": "puppetlabs-stdlib",
+      "name": "puppetlabs/stdlib",
       "version_requirement": ">= 9.0.0 < 10.0.0"
     }
   ],


### PR DESCRIPTION
I checked a few vox modules and these seem to use the / notation, so here is a PR to make this uniform

Fixes #72 

